### PR TITLE
Add Side Menu Support in VTreeNode (SeqInSideMenu & ShowInSideMenu)

### DIFF
--- a/BaseLibrary/Classes/VTreeNode.cs
+++ b/BaseLibrary/Classes/VTreeNode.cs
@@ -50,6 +50,13 @@ namespace VAdvantage.Classes
         /**	Color			*/
         //private color m_color;
 
+        /** Seq In Side Menu */
+        private int _seqInSideMenu;
+
+        /** Show In Side Menu */
+        private string _showInSideMenu;
+
+
         public const string ACTION_WORKBENCH = "B";
         /** WorkFlow = F */
         public const string ACTION_WORKFLOW = "F";
@@ -84,6 +91,8 @@ namespace VAdvantage.Classes
         public const int TYPE_USERCHOICE = 7;
         /**	Action - 8			*/
         public const int TYPE_DOCACTION = 8;
+
+
 
         /**************************************************************************/
 
@@ -233,7 +242,7 @@ namespace VAdvantage.Classes
                 node.Nodes.Clear();
                 this.Nodes.AddRange(myTreeNodeArray);
             }
-            catch 
+            catch
             {
 
             }
@@ -631,6 +640,31 @@ namespace VAdvantage.Classes
         {
             return new PreorderEnumerator(this);
         }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public int SeqInSideMenu
+        {
+            get { return _seqInSideMenu; }
+            set { _seqInSideMenu = value; }
+        }
+
+        /// <summary>
+        ///(Y/N)
+        /// </summary>
+        public string ShowInSideMenu
+        {
+            get { return _showInSideMenu; }
+            set
+            {
+                if (value != "Y" && value != "N")
+                    throw new Exception("ShowInSideMenu must be 'Y' or 'N'");
+                _showInSideMenu = value;
+            }
+        }
+
+
     }
 
     public class PreorderEnumerator : System.Collections.Generic.IEnumerator<object>
@@ -706,6 +740,9 @@ namespace VAdvantage.Classes
         {
 
         }
+
+
+
 
         //public TreeNode NextElement()
         //{


### PR DESCRIPTION
PR Description

We have added new properties to the VTreeNode to support rendering items in the user side menu.

The following fields were introduced:

SeqInSideMenu: Determines the order of items in the side menu.
ShowInSideMenu: Controls whether the menu item should be displayed (Y / N).
Implementation Details
private int _seqInSideMenu;

/** Show In Side Menu */
private string _showInSideMenu;

public int SeqInSideMenu
{
    get { return _seqInSideMenu; }
    set { _seqInSideMenu = value; }
}

public string ShowInSideMenu
{
    get { return _showInSideMenu; }
    set
    {
        if (value != "Y" && value != "N")
            throw new Exception("ShowInSideMenu must be 'Y' or 'N'");
        _showInSideMenu = value;
    }
}

These additions allow us to control both the visibility and ordering of menu items dynamically from metadata, enabling better customization of the user side menu.